### PR TITLE
Fix #1491: Generate id from :name: option in index

### DIFF
--- a/sphinxcontrib/qthelp/__init__.py
+++ b/sphinxcontrib/qthelp/__init__.py
@@ -39,6 +39,8 @@ __ = get_translation(__name__, 'console')
 _idpattern = re.compile(
     r'(?P<title>.+) (\((class in )?(?P<id>[\w\.]+)( (?P<descr>\w+))?\))$')
 
+_refidpattern = re.compile(
+    r'.*#(?P<id>.*)$')
 
 section_template = '<section title="%(title)s" ref="%(ref)s"/>'
 
@@ -213,6 +215,15 @@ class QtHelpBuilder(StandaloneHTMLBuilder):
 
         nameattr = html.escape(name, quote=True)
         refattr = html.escape(ref[1], quote=True)
+
+        if not id:
+            matchobj = _refidpattern.match(refattr)
+            if matchobj:
+                groupdict = matchobj.groupdict()
+                id = groupdict.get('id')
+                if id.startswith("index-"):
+                    id = None
+
         if id:
             item = ' ' * 12 + '<keyword name="%s" id="%s" ref="%s"/>' % (nameattr, id, refattr)
         else:

--- a/tests/roots/test-id/index.rst
+++ b/tests/roots/test-id/index.rst
@@ -1,0 +1,17 @@
+.. index:: test-id
+    :name: MY_TESTID
+
+test-id
+=======
+
+This is some text
+
+
+.. index:: test-id-next
+
+test-id2
+========
+
+
+
+

--- a/tests/test_qthelp.py
+++ b/tests/test_qthelp.py
@@ -132,3 +132,18 @@ def test_qthelp_title(app, status, warning):
 
     qhcp = (app.outdir / 'Python.qhcp').text()
     assert '<title>Sphinx &lt;b&gt;&#34;short&#34;&lt;/b&gt; title</title>' in qhcp
+
+
+@pytest.mark.sphinx('qthelp', testroot='id')
+def test_qthelp_id(app, status, warning):
+    app.builder.build_all()
+
+    et = etree_parse(app.outdir / 'Python.qhp')
+    keywords = et.find('.//keywords')
+    assert len(keywords) == 2
+    assert keywords[0].attrib == {'name': 'test-id',
+                                  'ref': 'index.html#my-testid',
+                                  'id': 'my-testid'}
+
+    assert keywords[1].attrib == {'name': 'test-id-next',
+                                  'ref': 'index.html#index-0'}


### PR DESCRIPTION
Hi!
Along from the old #1491 issue i want to generate the id attribute in the keyword tag for the qthelp files to have languange independent ids for the index Entries to use for https://doc.qt.io/qt-5/qhelpenginecore.html#documentsForIdentifier in qtHelpEngine.
Main part of the issue was to give the index an attribute to set this "ID". The qthelp builder does name the anchor to this ":name:", but does not generate an id attribute for it. This fix should do this for all "named" index entries. For those with standard naming "index-\d+" the id is NOT generated.

